### PR TITLE
chore(build): Fix build to make depending builds work

### DIFF
--- a/.github/workflows/github-actions-release.yaml
+++ b/.github/workflows/github-actions-release.yaml
@@ -8,7 +8,7 @@ on:
       - '*.*.*'
 
 env:
-  LANGUAGE_NAME: "mps-markdown"
+  LANGUAGE_NAME: "de.neumanntim.mps.markdown"
 
 jobs:
   call-build-workflow:

--- a/.github/workflows/workflow-build.yaml
+++ b/.github/workflows/workflow-build.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   PLUGIN_NAME: "de.neumanntim.mps.markdown"
-  LANGUAGE_NAME: "mps-markdown"
+  LANGUAGE_NAME: "de.neumanntim.mps.markdown"
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
  */
 
 ext.mpsVersion = "2022.2"
-ext.languageName = "mps-markdown"
+ext.languageName = "de.neumanntim.mps.markdown"
 ext.pluginName = "de.neumanntim.mps.markdown"
 
 ext.gradleScriptsRepoUrl = "https://github.com/neumantm/mps-gradle-scripts/raw/main"

--- a/build.xml
+++ b/build.xml
@@ -39,7 +39,216 @@
   <generator-settings id="m2m-defaults" strictMode="true" parallelThreads="8" inplaceTransform="false" warnWrongChild="true" createStaticRefs="true" skipUnmodifiedModels="${mps.generator.skipUnmodifiedModels}" />
   
   <target name="assemble" depends="classes, declare-mps-tasks">
-    <mkdir dir="${build.layout}" />
+    <mkdir dir="${build.layout}/de.neumanntim.mps.markdown" />
+    <mkdir dir="${build.layout}/de.neumanntim.mps.markdown/META-INF" />
+    <echoxml file="${build.layout}/de.neumanntim.mps.markdown/META-INF/plugin.xml">
+      <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+        <id>de.neumanntim.mps.markdown</id>
+        <name>de.neumanntim.mps.markdown</name>
+        <version>1.0</version>
+        <depends>jetbrains.mps.build</depends>
+        <depends>com.intellij.modules.platform</depends>
+        
+        <extensions defaultExtensionNs="com.intellij">
+          <mps.LanguageLibrary dir="/languages" />
+        </extensions>
+      </idea-plugin>
+    </echoxml>
+    <mkdir dir="${build.layout}/de.neumanntim.mps.markdown/lib" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF/plugin.xml">
+      <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+        <id>de.neumanntim.mps.markdown</id>
+        <name>de.neumanntim.mps.markdown</name>
+        <version>1.0</version>
+        <depends>jetbrains.mps.build</depends>
+        <depends>com.intellij.modules.platform</depends>
+        
+        <extensions defaultExtensionNs="com.intellij">
+          <mps.LanguageLibrary dir="/languages" />
+        </extensions>
+      </idea-plugin>
+    </echoxml>
+    <jar destfile="${build.layout}/de.neumanntim.mps.markdown/lib/de.neumanntim.mps.markdown.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
+    </jar>
+    <mkdir dir="${build.layout}/de.neumanntim.mps.markdown/languages" />
+    <mkdir dir="${build.layout}/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar1/META-INF/module.xml">
+      <module namespace="de.neumanntim.mps.markdown" type="language" uuid="8200bdbd-274e-492c-a4de-4849bbe9fc7a">
+        <dependencies>
+          <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
+          <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="rt" />
+          <module ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" kind="rt" />
+          <module ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" kind="rt" />
+          <module ref="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" kind="rt" />
+          <module ref="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" kind="rt" />
+          <module ref="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" kind="rt" />
+          <module ref="a3e4657f-a76c-45bb-bbda-c764596ecc65(jetbrains.mps.baseLanguage.logging.runtime)" kind="rt" />
+          <module ref="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" kind="rt" />
+          <module ref="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" kind="rt" />
+          <module ref="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" kind="rt" />
+          <module ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee(jetbrains.mps.lang.constraints.rules.runtime)" kind="rt" />
+          <module ref="0a98f3e2-decf-4e97-bf80-9109eccc59bb(jetbrains.mps.lang.feedback.problem.rules)" kind="rt" />
+          <module ref="9abaaae2-decf-4e97-bf80-9109e8b759cc(jetbrains.mps.lang.messages.api)" kind="rt" />
+          <module ref="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" kind="rt" />
+          <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
+          <module ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" kind="cl" />
+          <module ref="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" kind="cl" />
+          <module ref="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" kind="cl" />
+          <module ref="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
+          <language id="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" />
+          <language id="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" />
+          <language id="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" />
+          <language id="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" />
+          <language id="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" />
+          <language id="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" />
+          <language id="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" />
+          <language id="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" />
+          <language id="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" />
+          <language id="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" />
+          <language id="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" />
+          <language id="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" />
+          <language id="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" />
+          <language id="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" />
+          <language id="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" />
+          <language id="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" />
+          <language id="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" />
+          <language id="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" />
+          <language id="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" />
+          <language id="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" />
+          <language id="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" />
+          <language id="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" />
+          <language id="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" />
+          <language id="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" />
+          <language id="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" />
+          <language id="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" />
+          <language id="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" />
+          <language id="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="de.neumanntim.mps.markdown-src.jar" descriptor="de.neumanntim.mps.markdown.mpl" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown" />
+      <fileset dir="${basedir}/languages/de.neumanntim.mps.markdown" includes="icons/**, resources/**" />
+      <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1" />
+    </jar>
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar/META-INF/module.xml">
+      <module namespace="de.neumanntim.mps.markdown.generator" type="generator" uuid="a50a2409-cdab-46a2-b95a-fd8876c5d9f4">
+        <dependencies>
+          <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
+          <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="rt" />
+          <module ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)" kind="rt" />
+          <module ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" kind="rt" />
+          <module ref="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" kind="rt" />
+          <module ref="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" kind="rt" />
+          <module ref="a3e4657f-a76c-45bb-bbda-c764596ecc65(jetbrains.mps.baseLanguage.logging.runtime)" kind="rt" />
+          <module ref="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" kind="rt" />
+          <module ref="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" kind="rt" />
+          <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
+          <module ref="8200bdbd-274e-492c-a4de-4849bbe9fc7a(de.neumanntim.mps.markdown)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
+          <language id="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" />
+          <language id="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" />
+          <language id="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" />
+          <language id="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" />
+          <language id="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" />
+          <language id="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" />
+          <language id="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" />
+          <language id="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" />
+          <language id="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" />
+          <language id="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" />
+          <language id="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" />
+          <language id="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="de.neumanntim.mps.markdown-src.jar" descriptor="de.neumanntim.mps.markdown.mpl" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown-generator.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown.generator" />
+      <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-models">
+      <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates">
+      <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/templates" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown-src.jar" duplicate="preserve">
+      <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${basedir}/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.mpl" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-models" prefix="module/models" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates" prefix="module/generator/templates" />
+    </jar>
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar/META-INF/module.xml">
+      <module namespace="de.neumanntim.mps.markdown.build" type="solution" uuid="82b026ec-521a-41ab-9d6e-7ca53ee958e9">
+        <dependencies>
+          <module ref="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" />
+          <language id="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="de.neumanntim.mps.markdown.build-src.jar" descriptor="de.neumanntim.mps.markdown.build.msd" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.build.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown.build" />
+      <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models">
+      <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.build-src.jar" duplicate="preserve">
+      <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${basedir}/solutions/de.neumanntim.mps.markdown.build/de.neumanntim.mps.markdown.build.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models" prefix="module/models" />
+    </jar>
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip" />
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown" />
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/META-INF" />
@@ -57,9 +266,9 @@
       </idea-plugin>
     </echoxml>
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/lib" />
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF/plugin.xml">
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar2" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar2/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar2/META-INF/plugin.xml">
       <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
         <id>de.neumanntim.mps.markdown</id>
         <name>de.neumanntim.mps.markdown</name>
@@ -73,13 +282,13 @@
       </idea-plugin>
     </echoxml>
     <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/lib/de.neumanntim.mps.markdown.jar" duplicate="preserve">
-      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar2" />
     </jar>
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages" />
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown" />
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1" />
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1/META-INF" />
-    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar1/META-INF/module.xml">
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar3" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar3/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar3/META-INF/module.xml">
       <module namespace="de.neumanntim.mps.markdown" type="language" uuid="8200bdbd-274e-492c-a4de-4849bbe9fc7a">
         <dependencies>
           <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
@@ -146,11 +355,11 @@
       <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown" />
       <fileset dir="${basedir}/languages/de.neumanntim.mps.markdown" includes="icons/**, resources/**" />
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
-      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar3" />
     </jar>
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar" />
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar/META-INF/module.xml">
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar1" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar1/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar1/META-INF/module.xml">
       <module namespace="de.neumanntim.mps.markdown.generator" type="generator" uuid="a50a2409-cdab-46a2-b95a-fd8876c5d9f4">
         <dependencies>
           <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
@@ -191,12 +400,12 @@
     <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown-generator.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown.generator" />
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
-      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar1" />
     </jar>
-    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-models">
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-models1">
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates">
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates1">
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/templates" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
     <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown-src.jar" duplicate="preserve">
@@ -213,12 +422,12 @@
         <exclude name="**/*.mps" />
       </fileset>
       <zipfileset file="${basedir}/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.mpl" prefix="module" />
-      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-models" prefix="module/models" />
-      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates" prefix="module/generator/templates" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-models1" prefix="module/models" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates1" prefix="module/generator/templates" />
     </jar>
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar" />
-    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar/META-INF/module.xml">
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar1" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar1/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar1/META-INF/module.xml">
       <module namespace="de.neumanntim.mps.markdown.build" type="solution" uuid="82b026ec-521a-41ab-9d6e-7ca53ee958e9">
         <dependencies>
           <module ref="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" kind="cl" />
@@ -236,9 +445,9 @@
     <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.build.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown.build" />
       <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
-      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar1" />
     </jar>
-    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models">
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models1">
       <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
     <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.build-src.jar" duplicate="preserve">
@@ -249,7 +458,7 @@
         <exclude name="**/*.mps" />
       </fileset>
       <zipfileset file="${basedir}/solutions/de.neumanntim.mps.markdown.build/de.neumanntim.mps.markdown.build.msd" prefix="module" />
-      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models" prefix="module/models" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models1" prefix="module/models" />
     </jar>
     <zip destfile="${build.layout}/de.neumanntim.mps.markdown.zip">
       <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip" />

--- a/build.xml
+++ b/build.xml
@@ -8,9 +8,7 @@
   <property name="mps.macro.project_home" location="${basedir}" />
   <property name="deps_home" location="${basedir}/build/mps-bundle/dependencies" />
   <property name="artifacts.mps" location="${mps_home}" />
-  <property name="artifacts.de.itemis.mps.extensions" location="${deps_home}" />
   <property file="${artifacts.mps}/build.properties" prefix="import.mps" />
-  <property file="${artifacts.de.itemis.mps.extensions}/build.properties" prefix="import.de.itemis.mps.extensions" />
   <property name="mps.build.number" value="${import.mps.mps.build.number}" />
   <property name="mps.date" value="${import.mps.mps.date}" />
   <property name="mps.build.vcs.number" value="${import.mps.mps.build.vcs.number}" />
@@ -22,7 +20,6 @@
   <property name="mpsBootstrapCore.version.bugfixNr" value="${import.mps.mpsBootstrapCore.version.bugfixNr}" />
   <property name="mpsBootstrapCore.version.eap" value="${import.mps.mpsBootstrapCore.version.eap}" />
   <property name="mpsBootstrapCore.version" value="${import.mps.mpsBootstrapCore.version}" />
-  <property name="de.itemis.mps.extensions.versionNumber" value="${import.de.itemis.mps.extensions.de.itemis.mps.extensions.versionNumber}" />
   <property name="environment" value="env" />
   <property name="env.JAVA_HOME" value="${java.home}/.." />
   <property name="jdk.home" value="${env.JAVA_HOME}" />
@@ -43,16 +40,15 @@
   
   <target name="assemble" depends="classes, declare-mps-tasks">
     <mkdir dir="${build.layout}" />
-    <mkdir dir="${build.tmp}/default/mps-markdown.zip" />
-    <mkdir dir="${build.tmp}/default/mps-markdown.zip/mps.markdown" />
-    <mkdir dir="${build.tmp}/default/mps-markdown.zip/mps.markdown/META-INF" />
-    <echoxml file="${build.tmp}/default/mps-markdown.zip/mps.markdown/META-INF/plugin.xml">
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/META-INF/plugin.xml">
       <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
         <id>de.neumanntim.mps.markdown</id>
         <name>de.neumanntim.mps.markdown</name>
         <version>1.0</version>
-        <depends>jetbrains.mps.core</depends>
-        <depends>de.itemis.mps.extensions.build</depends>
+        <depends>jetbrains.mps.build</depends>
         <depends>com.intellij.modules.platform</depends>
         
         <extensions defaultExtensionNs="com.intellij">
@@ -60,31 +56,30 @@
         </extensions>
       </idea-plugin>
     </echoxml>
-    <mkdir dir="${build.tmp}/default/mps-markdown.zip/mps.markdown/lib" />
-    <mkdir dir="${build.tmp}/default/mps.markdown.jar" />
-    <mkdir dir="${build.tmp}/default/mps.markdown.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/mps.markdown.jar/META-INF/plugin.xml">
-      <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-        <id>de.neumanntim.mps.markdown</id>
-        <name>de.neumanntim.mps.markdown</name>
-        <version>1.0</version>
-        <depends>jetbrains.mps.core</depends>
-        <depends>de.itemis.mps.extensions.build</depends>
-        <depends>com.intellij.modules.platform</depends>
-        
-        <extensions defaultExtensionNs="com.intellij">
-          <mps.LanguageLibrary dir="/languages" />
-        </extensions>
-      </idea-plugin>
-    </echoxml>
-    <jar destfile="${build.tmp}/default/mps-markdown.zip/mps.markdown/lib/mps.markdown.jar" duplicate="preserve">
-      <fileset dir="${build.tmp}/default/mps.markdown.jar" />
-    </jar>
-    <mkdir dir="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages" />
-    <mkdir dir="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages/mps.markdown" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/lib" />
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF/module.xml">
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar/META-INF/plugin.xml">
+      <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+        <id>de.neumanntim.mps.markdown</id>
+        <name>de.neumanntim.mps.markdown</name>
+        <version>1.0</version>
+        <depends>jetbrains.mps.build</depends>
+        <depends>com.intellij.modules.platform</depends>
+        
+        <extensions defaultExtensionNs="com.intellij">
+          <mps.LanguageLibrary dir="/languages" />
+        </extensions>
+      </idea-plugin>
+    </echoxml>
+    <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/lib/de.neumanntim.mps.markdown.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
+    </jar>
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1" />
+    <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1/META-INF" />
+    <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.jar1/META-INF/module.xml">
       <module namespace="de.neumanntim.mps.markdown" type="language" uuid="8200bdbd-274e-492c-a4de-4849bbe9fc7a">
         <dependencies>
           <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
@@ -147,11 +142,11 @@
         <sources jar="de.neumanntim.mps.markdown-src.jar" descriptor="de.neumanntim.mps.markdown.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages/mps.markdown/de.neumanntim.mps.markdown.jar" duplicate="preserve">
+    <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown" />
       <fileset dir="${basedir}/languages/de.neumanntim.mps.markdown" includes="icons/**, resources/**" />
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
-      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar" />
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.jar1" />
     </jar>
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar" />
     <mkdir dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar/META-INF" />
@@ -193,7 +188,7 @@
         <sources jar="de.neumanntim.mps.markdown-src.jar" descriptor="de.neumanntim.mps.markdown.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages/mps.markdown/de.neumanntim.mps.markdown-generator.jar" duplicate="preserve">
+    <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown-generator.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown.generator" />
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown-generator.jar" />
@@ -204,7 +199,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-de.neumanntim.mps.markdown-generator-templates">
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/templates" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages/mps.markdown/de.neumanntim.mps.markdown-src.jar" duplicate="preserve">
+    <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown-src.jar" duplicate="preserve">
       <fileset dir="${project_home}/languages/de.neumanntim.mps.markdown/generator/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -226,7 +221,6 @@
     <echoxml file="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar/META-INF/module.xml">
       <module namespace="de.neumanntim.mps.markdown.build" type="solution" uuid="82b026ec-521a-41ab-9d6e-7ca53ee958e9">
         <dependencies>
-          <module ref="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" kind="cl" />
           <module ref="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" kind="cl" />
         </dependencies>
         <uses>
@@ -239,7 +233,7 @@
         <sources jar="de.neumanntim.mps.markdown.build-src.jar" descriptor="de.neumanntim.mps.markdown.build.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages/mps.markdown/de.neumanntim.mps.markdown.build.jar" duplicate="preserve">
+    <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.build.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/de.neumanntim.mps.markdown.build" />
       <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.build.jar" />
@@ -247,7 +241,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models">
       <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/mps-markdown.zip/mps.markdown/languages/mps.markdown/de.neumanntim.mps.markdown.build-src.jar" duplicate="preserve">
+    <jar destfile="${build.tmp}/default/de.neumanntim.mps.markdown.zip/de.neumanntim.mps.markdown/languages/de.neumanntim.mps.markdown/de.neumanntim.mps.markdown.build-src.jar" duplicate="preserve">
       <fileset dir="${project_home}/solutions/de.neumanntim.mps.markdown.build/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -257,10 +251,10 @@
       <zipfileset file="${basedir}/solutions/de.neumanntim.mps.markdown.build/de.neumanntim.mps.markdown.build.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-de.neumanntim.mps.markdown.build-models" prefix="module/models" />
     </jar>
-    <zip destfile="${build.layout}/mps-markdown.zip">
-      <fileset dir="${build.tmp}/default/mps-markdown.zip" />
+    <zip destfile="${build.layout}/de.neumanntim.mps.markdown.zip">
+      <fileset dir="${build.tmp}/default/de.neumanntim.mps.markdown.zip" />
     </zip>
-    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}${line.separator}de.itemis.mps.extensions.versionNumber=${de.itemis.mps.extensions.versionNumber}</echo>
+    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
   </target>
   
   <target name="buildDependents" />
@@ -288,7 +282,6 @@
     <echo message="generating" />
     <generate fork="true" logLevel="${mps.ant.log}">      
       <settings refid="m2m-defaults" />
-      <plugin path="${artifacts.de.itemis.mps.extensions}/de.itemis.mps.extensions.build" />
       <plugin path="${artifacts.mps}/plugins/mps-build" />
       <plugin path="${artifacts.mps}/plugins/mps-core" />
       <library file="${artifacts.mps}/languages/baseLanguage/closures.runtime.jar" />
@@ -540,9 +533,7 @@
       <src>
         <path location="${project_home}/solutions/de.neumanntim.mps.markdown.build/source_gen" />
       </src>
-      <classpath>
-        <fileset file="${artifacts.de.itemis.mps.extensions}/de.itemis.mps.extensions.build/languages/de.itemis.mps.extensions.build/de.itemis.mps.extensions.build.jar" />
-      </classpath>
+      <classpath />
     </javac>
   </target>
   

--- a/solutions/de.neumanntim.mps.markdown.build/de.neumanntim.mps.markdown.build.msd
+++ b/solutions/de.neumanntim.mps.markdown.build/de.neumanntim.mps.markdown.build.msd
@@ -13,7 +13,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
-    <dependency reexport="false">f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -21,7 +20,6 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" version="0" />
     <module reference="82b026ec-521a-41ab-9d6e-7ca53ee958e9(de.neumanntim.mps.markdown.build)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
   </dependencyVersions>

--- a/solutions/de.neumanntim.mps.markdown.build/models/de.neumanntim.mps.markdown.build.mps
+++ b/solutions/de.neumanntim.mps.markdown.build/models/de.neumanntim.mps.markdown.build.mps
@@ -7,7 +7,6 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="90a9" ref="r:fb24ac52-5985-4947-bba9-25be6fd32c1a(de.itemis.mps.extensions.build)" />
   </imports>
   <registry>
     <language id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml">
@@ -178,17 +177,11 @@
         <ref role="398BVh" node="2ombABepQel" resolve="mps_home" />
       </node>
     </node>
-    <node concept="2sgV4H" id="38MlCki16zm" role="1l3spa">
-      <ref role="1l3spb" to="90a9:2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
-      <node concept="398BVA" id="38MlCki16zr" role="2JcizS">
-        <ref role="398BVh" node="1JDJfMrh4X" resolve="deps_home" />
-      </node>
-    </node>
     <node concept="1l3spV" id="2ombABepQeM" role="1l3spN">
       <node concept="3981dG" id="2ombABepQeN" role="39821P">
         <node concept="3_J27D" id="2ombABepQeO" role="Nbhlr">
           <node concept="3Mxwew" id="2ombABepQeP" role="3MwsjC">
-            <property role="3MwjfP" value="mps-markdown.zip" />
+            <property role="3MwjfP" value="de.neumanntim.mps.markdown.zip" />
           </node>
         </node>
         <node concept="m$_wl" id="2ombABepQeQ" role="39821P">
@@ -213,14 +206,11 @@
         <ref role="m$f5T" node="2ombABepQe$" resolve="mps-markdown" />
       </node>
       <node concept="m$_yC" id="2ombABepQeF" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="1JDJfMrh7D" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:4hvHh3QW$Eh" resolve="de.itemis.mps.extensions.build" />
+        <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
       </node>
       <node concept="3_J27D" id="2ombABepQeG" role="m_cZH">
         <node concept="3Mxwew" id="2ombABepQeH" role="3MwsjC">
-          <property role="3MwjfP" value="mps.markdown" />
+          <property role="3MwjfP" value="de.neumanntim.mps.markdown" />
         </node>
       </node>
       <node concept="2pNNFK" id="2ombABepQeI" role="20twgj">
@@ -231,7 +221,7 @@
       </node>
     </node>
     <node concept="2G$12M" id="2ombABepQe$" role="3989C9">
-      <property role="TrG5h" value="mps.markdown" />
+      <property role="TrG5h" value="de.neumanntim.mps.markdown" />
       <node concept="1E1JtD" id="2ombABepQet" role="2G$12L">
         <property role="TrG5h" value="de.neumanntim.mps.markdown" />
         <property role="3LESm3" value="8200bdbd-274e-492c-a4de-4849bbe9fc7a" />
@@ -337,11 +327,6 @@
                 <property role="2Ry0Am" value="de.neumanntim.mps.markdown.build.msd" />
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1JDJfMrh70" role="3bR37C">
-          <node concept="3bR9La" id="1JDJfMrh71" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:PE3B26VOkn" resolve="de.itemis.mps.extensions.build" />
           </node>
         </node>
         <node concept="1SiIV0" id="1JDJfMrh72" role="3bR37C">

--- a/solutions/de.neumanntim.mps.markdown.build/models/de.neumanntim.mps.markdown.build.mps
+++ b/solutions/de.neumanntim.mps.markdown.build/models/de.neumanntim.mps.markdown.build.mps
@@ -178,15 +178,19 @@
       </node>
     </node>
     <node concept="1l3spV" id="2ombABepQeM" role="1l3spN">
-      <node concept="3981dG" id="2ombABepQeN" role="39821P">
-        <node concept="3_J27D" id="2ombABepQeO" role="Nbhlr">
-          <node concept="3Mxwew" id="2ombABepQeP" role="3MwsjC">
+      <node concept="m$_wl" id="4s518u6vAxg" role="39821P">
+        <ref role="m_rDy" node="2ombABepQe_" resolve="de.neumanntim.mps.markdown" />
+        <node concept="pUk6x" id="4s518u6vAxr" role="pUk7w" />
+      </node>
+      <node concept="3981dG" id="6lnvyQxyzDY" role="39821P">
+        <node concept="3_J27D" id="6lnvyQxyzE0" role="Nbhlr">
+          <node concept="3Mxwew" id="6lnvyQxyzE6" role="3MwsjC">
             <property role="3MwjfP" value="de.neumanntim.mps.markdown.zip" />
           </node>
         </node>
-        <node concept="m$_wl" id="2ombABepQeQ" role="39821P">
-          <ref role="m_rDy" node="2ombABepQe_" resolve="mps_markdown" />
-          <node concept="pUk6x" id="2ombABepQeR" role="pUk7w" />
+        <node concept="m$_wl" id="6lnvyQxyzE8" role="39821P">
+          <ref role="m_rDy" node="2ombABepQe_" resolve="de.neumanntim.mps.markdown" />
+          <node concept="pUk6x" id="6lnvyQxyzEc" role="pUk7w" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
Also remove dependency to de.itemis.mps.extensions.build As we only need mps extensions because of TextGenGen. But our languages do not depend on that.